### PR TITLE
publish all joint transforms if flag is set

### DIFF
--- a/src/smart_state_publisher.cpp
+++ b/src/smart_state_publisher.cpp
@@ -151,7 +151,7 @@ int main(int argc, char** argv)
             throw;
         }
 
-        std::vector<bool> jointUpdated(model->getJointModels().size(), publishAllJoints);
+        std::vector<bool> jointUpdated(model->getJointModels().size(), false);
         for(std::size_t j = 0; j < jointUpdated.size(); ++j)
             jointUpdated[j] = state.dirtyJointTransform(model->getJointModel(j));
 
@@ -159,7 +159,7 @@ int main(int argc, char** argv)
 
         for(std::size_t j = 0; j < jointUpdated.size(); ++j)
         {
-            if(!jointUpdated[j])
+            if(!publishAllJoints && !jointUpdated[j])
                 continue;
 
             auto joint = model->getJointModel(j);


### PR DESCRIPTION
Joint transformes are not updated since `jointUpdated[j] = state.dirtyJointTransform(model->getJointModel(j));` overrides the `publishAllJoints` flag.
This should fix the problem.